### PR TITLE
Add dependency pyyaml-35

### DIFF
--- a/src/pkg/manifests/system:zones:brand:bhyve.p5m
+++ b/src/pkg/manifests/system:zones:brand:bhyve.p5m
@@ -38,3 +38,4 @@ depend type=require fmri=network/netcat
 depend type=require fmri=system/bhyve
 depend type=require fmri=system/bhyve/firmware
 depend type=require fmri=system/library/bhyve
+depend type=require fmri=library/python/pyyaml-35


### PR DESCRIPTION
because yaml is needed and bhyve init script is using python-35